### PR TITLE
Agregar menu

### DIFF
--- a/Autoinstall.sh
+++ b/Autoinstall.sh
@@ -10,10 +10,41 @@ adduser $USERNAME sudo
 apt-get install -y curl python-pip flashplugin-nonfree openjdk-7-jdk gparted git
 
 # Administrador de archivos
-apt-get  install -y nemo
+# Pequeño menu para seleccionar administrador de archivos
+echo "Administradores de archivos"
+echo "---------------------------"
+echo
+echo "1) nemo"
+echo "2) thunar"
+read -p "Seleccione cual desea instalar: " VAR
+echo
+case "$VAR" in
+1) apt-get install -y nemo ;;
+2) apt-get install -y thunar ;;
+*) echo "Opcion invalida intente de nuevo" ;;
+esac
+
+# Limpiamos la consola
+clear
 
 # Procesador de texto
-apt-get install -y vim-nox
+echo "Administradores de archivos"
+echo "---------------------------"
+echo
+echo "1) vim-nox"
+echo "2) gedit"
+echo "3) mousepad"
+echo "4) leafpad"
+echo
+read -p "Seleccione cual desea instalar: " VAR
+echo
+case "$VAR" in
+1) apt-get install -y vim-nox ;;
+2) apt-get install -y gedit ;;
+3) apt-get install -y mousepad ;;
+4) apt-get install -y leafpad ;;
+*) echo "Opcion invalida intente de nuevo" ;;
+esac
 
 # Terminal
 apt-get install -y terminator


### PR DESCRIPTION
Entiendo la intención de que el usuario sea participe de la instalación también pero también creo que agregar un menú con opciones hace que el proceso de automatización sea interrumpido. Habría que ver otra manera en donde no se interrumpa el script, leer algún archivo de configuración en donde estén las aplicaciones a instalar y que se puedan agregar y de ahí las tome sin interrumpir el proceso. Estoy trabajando en algo un poco mas completo para poder llevarlo a algo mas user-friendly
